### PR TITLE
Fixes #7

### DIFF
--- a/drawing_splitter.py
+++ b/drawing_splitter.py
@@ -48,7 +48,7 @@ def get_drawing_numbers(filename, num_of_pages, number_element, region):
                 print(f'\tPage {page_number + 1} of '
                       f'{num_of_pages}: Drawing number not found. '
                       'Manually rename file.')
-                drawing_numbers.append(f'drawing_{page_number +1}')
+                drawing_numbers.append(f'drawing_{page_number + 1}')
     return drawing_numbers
 
 
@@ -57,23 +57,18 @@ def save_drawings(filename, num_of_pages, drawing_numbers, output_folder):
     the drawing number."""
     warnings.filterwarnings('ignore')
     with open(filename, 'rb') as pdf:
-        if len(drawing_numbers):
-            pdf_reader = PyPDF2.PdfFileReader(pdf, strict=False)
-            for page_number in range(num_of_pages):
-                if drawing_numbers[page_number] is None:
-                    continue
-                pdf_writer = PyPDF2.PdfFileWriter()
-                page = pdf_reader.getPage(page_number)
-                pdf_writer.addPage(page)
-                output_filename = drawing_numbers[page_number] + '.pdf'
-                os.makedirs(output_folder, exist_ok=True)
-                output_fullpath = os.path.join(output_folder, output_filename)
-                pdf_output_file = open(output_fullpath, 'wb')
-                pdf_writer.write(pdf_output_file)
-                pdf_output_file.close()
-            print(f'Drawings saved: {len(drawing_numbers)}')
-        else:
-            print('No drawings could be saved.')
+        pdf_reader = PyPDF2.PdfFileReader(pdf, strict=False)
+        for page_number in range(num_of_pages):
+            pdf_writer = PyPDF2.PdfFileWriter()
+            page = pdf_reader.getPage(page_number)
+            pdf_writer.addPage(page)
+            output_filename = drawing_numbers[page_number] + '.pdf'
+            os.makedirs(output_folder, exist_ok=True)
+            output_fullpath = os.path.join(output_folder, output_filename)
+            pdf_output_file = open(output_fullpath, 'wb')
+            pdf_writer.write(pdf_output_file)
+            pdf_output_file.close()
+        print(f'Drawings saved: {len(drawing_numbers)}')
     warnings.filterwarnings('default')
 
 

--- a/drawing_splitter.py
+++ b/drawing_splitter.py
@@ -46,7 +46,9 @@ def get_drawing_numbers(filename, num_of_pages, number_element, region):
                 drawing_numbers.append(drawing_number)
             except (TypeError, AttributeError):
                 print(f'\tPage {page_number + 1} of '
-                      f'{num_of_pages}: invalid drawing')
+                      f'{num_of_pages}: Drawing number not found. '
+                      'Manually rename file.')
+                drawing_numbers.append(f'drawing_{page_number +1}')
     return drawing_numbers
 
 
@@ -58,6 +60,8 @@ def save_drawings(filename, num_of_pages, drawing_numbers, output_folder):
         if len(drawing_numbers):
             pdf_reader = PyPDF2.PdfFileReader(pdf, strict=False)
             for page_number in range(num_of_pages):
+                if drawing_numbers[page_number] is None:
+                    continue
                 pdf_writer = PyPDF2.PdfFileWriter()
                 page = pdf_reader.getPage(page_number)
                 pdf_writer.addPage(page)


### PR DESCRIPTION
Fixes issue #7  
If drawing number cannot be found, the drawing is saved with a generic name. "drawing_x.pdf" where x is the page number from the original PDF.
The user is notified that they must manually rename these files.